### PR TITLE
Improve JSON patch handling and add mass save

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -52,3 +52,8 @@ OnexExplorer es una herramienta de c\u00f3digo abierto para desempaquetar y volv
 - NSedData
 - NSgrdData
 - NSpmData
+
+## Notas
+
+- Al importar parches JSON la ruta de cada archivo se determina desde la ubicación real del JSON, por lo que funciona igual en Windows o Linux.
+- Puedes aplicar varios parches a diferentes archivos `.NOS` de forma simultánea eligiendo varios JSON y usar la opción **[3rJoselu] Save all .NOS** para guardar todos los archivos abiertos de una sola vez.

--- a/Source/MainWindow.h
+++ b/Source/MainWindow.h
@@ -36,6 +36,7 @@ public slots:
     void on_actionExport_with_config_triggered();
     void on_actionImport_from_config_triggered();
     void on_actionApplyPatch_triggered();
+    void on_actionSaveAllNos_triggered();
     void on_addButton_clicked();
     void on_deleteButton_clicked();
     void filterItems();

--- a/Source/mainwindow.ui
+++ b/Source/mainwindow.ui
@@ -207,6 +207,7 @@
                 <addaction name="actionExport_with_config"/>
                 <addaction name="actionImport_from_config"/>
                 <addaction name="actionApplyPatch"/>
+                <addaction name="actionSaveAllNos"/>
                 <addaction name="separator"/>
                 <addaction name="actionRename"/>
             </widget>
@@ -369,6 +370,14 @@
             </property>
             <property name="toolTip">
                 <string>Load items that should be added or replaced from a config file</string>
+            </property>
+        </action>
+        <action name="actionSaveAllNos">
+            <property name="text">
+                <string>[3rJoselu] Save all .NOS</string>
+            </property>
+            <property name="toolTip">
+                <string>Save every open .NOS archive</string>
             </property>
         </action>
     </widget>


### PR DESCRIPTION
## Summary
- fix path resolution using QFileInfo and QDir
- allow selecting multiple NOS items to apply multiple JSON patches
- add `[3rJoselu] Save all .NOS` option
- document JSON path handling and new features

## Testing
- `cmake -S . -B build-test` *(fails: FindQt5Core.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eccc33cf08332a139511f5aaebbd1