### PR TITLE
Fix dir separator

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -17,6 +17,7 @@ OnexExplorer es una herramienta de c\u00f3digo abierto para desempaquetar y volv
 - Previsualizar textos, im\u00e1genes y modelos 3D.
 - Extraer archivos o carpetas completas.
 - Reemplazar contenido existente y a\u00f1adir nuevos recursos.
+- Todas las rutas devueltas respetan el separador del sistema.
 
 ## Archivos soportados actualmente
 

--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -3,6 +3,7 @@
 #include "Ui/TreeItems/OnexNSmpData.h"
 #include <QScrollArea>
 #include <QJsonDocument>
+#include <QDir>
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
@@ -443,7 +444,7 @@ QString MainWindow::getSelectedDirectory(const QString &suggestion) {
     QString dir = QFileDialog::getExistingDirectory(nullptr, tr("Select Directory"), suggestion);
     if (dir.isEmpty())
         return dir;
-    return dir + "/";
+    return dir + QDir::separator();
 }
 
 QString MainWindow::getOpenFile(const QString &suggestion, const QString &filter) {


### PR DESCRIPTION
## Summary
- use `QDir::separator()` when returning directory
- include `QDir` header
- document path separator behavior

## Testing
- `cmake -S . -B codex_build` *(fails: Could not find a package configuration file provided by "Qt5Core")*

------
https://chatgpt.com/codex/tasks/task_e_685ed534925c83329a6f0635fa20d39f