### PR TITLE
Fix directory separator handling

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -56,4 +56,5 @@ OnexExplorer es una herramienta de c\u00f3digo abierto para desempaquetar y volv
 ## Notas
 
 - Al importar parches JSON la ruta de cada archivo se determina desde la ubicación real del JSON, por lo que funciona igual en Windows o Linux.
+- Todas las rutas devueltas respetan el separador del sistema.
 - Puedes aplicar varios parches a diferentes archivos `.NOS` de forma simultánea eligiendo varios JSON y usar la opción **[3rJoselu] Save all .NOS** para guardar todos los archivos abiertos de una sola vez.

--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -487,7 +487,7 @@ QString MainWindow::getSelectedDirectory(const QString &suggestion) {
     QString dir = QFileDialog::getExistingDirectory(nullptr, tr("Select Directory"), suggestion);
     if (dir.isEmpty())
         return dir;
-    return dir + "/";
+    return dir + QDir::separator();
 }
 
 QString MainWindow::getOpenFile(const QString &suggestion, const QString &filter) {


### PR DESCRIPTION
## Summary
- use `QDir::separator()` when returning directories in `getSelectedDirectory`
- add note in README about respecting OS directory separators

## Testing
- `cmake ..` *(fails: Could not find Qt5CoreConfig.cmake)*
- `cmake -DCMAKE_SYSTEM_NAME=Windows ..` *(fails: unrecognized option '--major-image-version')*

------
https://chatgpt.com/codex/tasks/task_e_685ed73bd43c8332bdd8f537797f1c52