### PR TITLE
Fix mass save shortcut

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -57,6 +57,7 @@ OnexExplorer es una herramienta de código abierto para desempaquetar y volver a
 
 - Al importar parches JSON la ruta de cada archivo se determina desde la ubicación real del JSON, por lo que funciona igual en Windows o Linux.
 - Todas las rutas devueltas respetan el separador del sistema.
-- Puedes aplicar varios parches a diferentes archivos `.NOS` de forma simultánea eligiendo varios JSON y usar la opción **[3rJoselu] Save all .NOS** para guardar todos los archivos abiertos de una sola vez.
+- Puedes aplicar varios parches a diferentes archivos `.NOS` de forma simultánea eligiendo varios JSON y usar la opción **[3rJoselu] Save all .NOS (CTRL+S)** para guardar todos los archivos abiertos de una sola vez.
 - Se eliminaron los botones de invitaci\u00f3n a Discord y Ko-fi para una interfaz m\u00e1s limpia.
 - La lista de archivos en el árbol ahora se ordena de forma natural para que elementos como `31439_2` aparezcan en el orden correcto.
+- La combinación **CTRL+S** ahora ejecuta el guardado masivo de todos los archivos abiertos.

--- a/Source/mainwindow.ui
+++ b/Source/mainwindow.ui
@@ -195,9 +195,6 @@
             <property name="text">
                 <string>Save as...</string>
             </property>
-            <property name="shortcut">
-                <string>Ctrl+S</string>
-            </property>
         </action>
         <action name="actionClose_selected">
             <property name="text">
@@ -339,10 +336,13 @@
         </action>
         <action name="actionSaveAllNos">
             <property name="text">
-                <string>[3rJoselu] Save all .NOS</string>
+                <string>[3rJoselu] Save all .NOS (CTRL+S)</string>
             </property>
             <property name="toolTip">
                 <string>Save every open .NOS archive</string>
+            </property>
+            <property name="shortcut">
+                <string>Ctrl+S</string>
             </property>
         </action>
     </widget>


### PR DESCRIPTION
## Summary
- set `CTRL+S` as the shortcut for `[3rJoselu] Save all .NOS`
- remove the shortcut from `Save as...`
- document the new mass save hotkey in Spanish README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ee77faad08332819e2e9867a77df8